### PR TITLE
Basic C11 stuff; aligned_alloc; ucontext.h cleanup

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2012-03-09  Joseph Myers  <joseph@codesourcery.com>
+
+	[BZ #13566]
+	* libio/stdio.h (gets): Always declare for C++ up to C++11 without
+	checking __USE_GNU.
+
 2012-01-07  Ulrich Drepper  <drepper@gmail.com>
 
 	* libio/stdio.h: Do not declare gets at all for _GNU_SOURCE.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2011-12-23  Ulrich Drepper  <drepper@gmail.com>
+
+	* include/features.h: Handle __STDC_VERSION__ >= 201112 and
+	_ISOC11_SOURCE.
+
 2011-04-01  Andreas Schwab  <schwab@redhat.com>
 
 	* sysdeps/unix/sysv/linux/Makefile (sysdep_headers): Add

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,173 @@
+2017-05-11  Joseph Myers  <joseph@codesourcery.com>
+
+	[BZ #21457]
+	* sysdeps/arm/sys/ucontext.h (R0): Condition on [__USE_MISC].
+	(R1): Likewise.
+	(R2): Likewise.
+	(R3): Likewise.
+	(R4): Likewise.
+	(R5): Likewise.
+	(R6): Likewise.
+	(R7): Likewise.
+	(R8): Likewise.
+	(R9): Likewise.
+	(R10): Likewise.
+	(R11): Likewise.
+	(R12): Likewise.
+	(R13): Likewise.
+	(R14): Likewise.
+	(R15): Likewise.
+	* sysdeps/i386/sys/ucontext.h (REG_GS): Likewise.
+	(REG_FS): Likewise.
+	(REG_ES): Likewise.
+	(REG_DS): Likewise.
+	(REG_EDI): Likewise.
+	(REG_ESI): Likewise.
+	(REG_EBP): Likewise.
+	(REG_ESP): Likewise.
+	(REG_EBX): Likewise.
+	(REG_EDX): Likewise.
+	(REG_ECX): Likewise.
+	(REG_EAX): Likewise.
+	(REG_TRAPNO): Likewise.
+	(REG_ERR): Likewise.
+	(REG_EIP): Likewise.
+	(REG_CS): Likewise.
+	(REG_EFL): Likewise.
+	(REG_UESP): Likewise.
+	(REG_SS): Likewise.
+	* sysdeps/m68k/sys/ucontext.h (R_D0): Likewise.
+	(R_D1): Likewise.
+	(R_D2): Likewise.
+	(R_D3): Likewise.
+	(R_D4): Likewise.
+	(R_D5): Likewise.
+	(R_D6): Likewise.
+	(R_D7): Likewise.
+	(R_A0): Likewise.
+	(R_A1): Likewise.
+	(R_A2): Likewise.
+	(R_A3): Likewise.
+	(R_A4): Likewise.
+	(R_A5): Likewise.
+	(R_A6): Likewise.
+	(R_A7): Likewise.
+	(R_SP): Likewise.
+	(R_PC): Likewise.
+	(R_PS): Likewise.
+	(fpregset_t): Likewise.
+	(MCONTEXT_VERSION): Likewise.
+	* sysdeps/mips/sys/ucontext.h (CTX_R0): Likewise.
+	(CTX_AT): Likewise.
+	(CTX_V0): Likewise.
+	(CTX_V1): Likewise.
+	(CTX_A0): Likewise.
+	(CTX_A1): Likewise.
+	(CTX_A2): Likewise.
+	(CTX_A3): Likewise.
+	(CTX_T0): Likewise.
+	(CTX_T1): Likewise.
+	(CTX_T2): Likewise.
+	(CTX_T3): Likewise.
+	(CTX_T4): Likewise.
+	(CTX_T5): Likewise.
+	(CTX_T6): Likewise.
+	(CTX_T7): Likewise.
+	(CTX_S0): Likewise.
+	(CTX_S1): Likewise.
+	(CTX_S2): Likewise.
+	(CTX_S3): Likewise.
+	(CTX_S4): Likewise.
+	(CTX_S5): Likewise.
+	(CTX_S6): Likewise.
+	(CTX_S7): Likewise.
+	(CTX_T8): Likewise.
+	(CTX_T9): Likewise.
+	(CTX_K0): Likewise.
+	(CTX_K1): Likewise.
+	(CTX_GP): Likewise.
+	(CTX_SP): Likewise.
+	(CTX_S8): Likewise.
+	(CTX_RA): Likewise.
+	(CTX_MDLO): Likewise.
+	(CTX_MDHI): Likewise.
+	(CTX_CAUSE): Likewise.
+	(CTX_EPC): Likewise.
+	* sysdeps/unix/sysv/linux/aarch64/sys/ucontext.h: Condition
+	inclusion of <sys/procfs.h> on [__USE_MISC].
+	(greg_t): Condition on [__USE_MISC].
+	(gregset_t): Likewise.
+	(fpregset_t): Likewise.
+	* sysdeps/unix/sysv/linux/arm/sys/ucontext.h (greg_t): Likewise.
+	(NGREG): Likewise.
+	(gregset_t): Likewise.
+	(REG_R0): Likewise.
+	(REG_R1): Likewise.
+	(REG_R2): Likewise.
+	(REG_R3): Likewise.
+	(REG_R4): Likewise.
+	(REG_R5): Likewise.
+	(REG_R6): Likewise.
+	(REG_R7): Likewise.
+	(REG_R8): Likewise.
+	(REG_R9): Likewise.
+	(REG_R10): Likewise.
+	(REG_R11): Likewise.
+	(REG_R12): Likewise.
+	(REG_R13): Likewise.
+	(REG_R14): Likewise.
+	(REG_R15): Likewise.
+	(struct _libc_fpstate): Likewise.
+	(fpregset_t): Likewise.
+	* sysdeps/unix/sysv/linux/hppa/sys/ucontext.h (NGREG): Likewise.
+	(NFPREG): Likewise.
+	(gregset_t): Likewise.
+	(fpregset_t): Likewise.
+	* sysdeps/unix/sysv/linux/m68k/sys/ucontext.h (R_D0): Likewise.
+	(R_D1): Likewise.
+	(R_D2): Likewise.
+	(R_D3): Likewise.
+	(R_D4): Likewise.
+	(R_D5): Likewise.
+	(R_D6): Likewise.
+	(R_D7): Likewise.
+	(R_A0): Likewise.
+	(R_A1): Likewise.
+	(R_A2): Likewise.
+	(R_A3): Likewise.
+	(R_A4): Likewise.
+	(R_A5): Likewise.
+	(R_A6): Likewise.
+	(R_A7): Likewise.
+	(R_SP): Likewise.
+	(R_PC): Likewise.
+	(R_PS): Likewise.
+	(fpregset_t): Likewise.
+	(MCONTEXT_VERSION): Likewise.
+	* sysdeps/unix/sysv/linux/nios2/sys/ucontext.h (MCONTEXT_VERSION):
+	Likewise.
+	* sysdeps/unix/sysv/linux/sh/sys/ucontext.h (REG_R0): Likewise.
+	(REG_R1): Likewise.
+	(REG_R2): Likewise.
+	(REG_R3): Likewise.
+	(REG_R4): Likewise.
+	(REG_R5): Likewise.
+	(REG_R6): Likewise.
+	(REG_R7): Likewise.
+	(REG_R8): Likewise.
+	(REG_R9): Likewise.
+	(REG_R10): Likewise.
+	(REG_R11): Likewise.
+	(REG_R12): Likewise.
+	(REG_R13): Likewise.
+	(REG_R14): Likewise.
+	(REG_R15): Likewise.
+	* sysdeps/unix/sysv/linux/tile/sys/ucontext.h: Condition inclusion
+	of <arch/abi.h> on [__USE_MISC].
+	(greg_t): Condition on [__USE_MISC].
+	(NGREG): Likewise.
+	(gregset_t): Likewise.
+
 2012-03-09  Joseph Myers  <joseph@codesourcery.com>
 
 	[BZ #13566]

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2011-12-23  Ulrich Drepper  <drepper@gmail.com>
 
+	[BZ #13528]
+	* libio/stdio.h: Do not declare gets for ISO C11 and _GNU_SOURCE.
+
 	[BZ #13529]
 	* assert/assert.h (static_assert): Define.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2012-01-06  Joseph Myers  <joseph@codesourcery.com>
+
+	[BZ #13566]
+	* assert/assert.h (static_assert): Don't define for C++.
+	* libio/stdio.h (gets): Do declare for C++ <= C++11.
+	* wcsmbs/uchar.h (char16_t, char32_t): Don't typedef for C++11.
+
 2011-12-23  Ulrich Drepper  <drepper@gmail.com>
 
 	[BZ #13531]

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 2011-12-23  Ulrich Drepper  <drepper@gmail.com>
 
+	[BZ #13529]
+	* assert/assert.h (static_assert): Define.
+
+	[BZ #13526]
 	* include/features.h: Handle __STDC_VERSION__ >= 201112 and
 	_ISOC11_SOURCE.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 2011-12-23  Ulrich Drepper  <drepper@gmail.com>
 
+	[BZ 13527]
+	* stdlib/stdlib.h: Make at_quick_exit and quick_exit available for
+	ISO C11.
+
 	* include/features.h: Define __USE_ISOCXX11 when compiling ISo C++11
 	code.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,10 +1,16 @@
 2011-12-23  Ulrich Drepper  <drepper@gmail.com>
 
+	[BZ #13531]
+	* malloc/malloc.c: Define alias aligned_alloc for public_mEMALIGn.
+	* stdlib/stdlib.h: Declare aligned_alloc.
+	* Versions.def: Add GLIBC_2.16 for libc.
+	* malloc/Versions: Export aligned_alloc from libc for GLIBC_2.16.
+
 	[BZ 13527]
 	* stdlib/stdlib.h: Make at_quick_exit and quick_exit available for
 	ISO C11.
 
-	* include/features.h: Define __USE_ISOCXX11 when compiling ISo C++11
+	* include/features.h: Define __USE_ISOCXX11 when compiling ISO C++11
 	code.
 
 	[BZ #13528]

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2012-01-07  Ulrich Drepper  <drepper@gmail.com>
+
+	* libio/stdio.h: Do not declare gets at all for _GNU_SOURCE.
+
 2012-01-06  Joseph Myers  <joseph@codesourcery.com>
 
 	[BZ #13566]

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 2011-12-23  Ulrich Drepper  <drepper@gmail.com>
 
+	* include/features.h: Define __USE_ISOCXX11 when compiling ISo C++11
+	code.
+
 	[BZ #13528]
 	* libio/stdio.h: Do not declare gets for ISO C11 and _GNU_SOURCE.
 

--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,13 @@ See the end for copying conditions.
 Please send GNU C library bug reports via <http://sources.redhat.com/bugzilla/>
 using `glibc' in the "product" field.
 
+Backported from
+Version 2.16
+
+* The following bugs are resolved with this release:
+
+  13526, 13529
+
 Version 2.12.2
 
 * The following bugs are resolved with this release:

--- a/NEWS
+++ b/NEWS
@@ -10,7 +10,8 @@ Version 2.16
 
 * The following bugs are resolved with this release:
 
-  13526, 13529
+  13526, 13528, 13529
+
 
 Version 2.12.2
 

--- a/NEWS
+++ b/NEWS
@@ -10,7 +10,7 @@ Version 2.16
 
 * The following bugs are resolved with this release:
 
-  13526, 13528, 13529
+  13526, 13527, 13528, 13529
 
 
 Version 2.12.2

--- a/NEWS
+++ b/NEWS
@@ -10,7 +10,20 @@ Version 2.16
 
 * The following bugs are resolved with this release:
 
-  13526, 13527, 13528, 13529
+  13526, 13527, 13528, 13529, 13531
+
+* ISO C11 support:
+
+  + define static_assert
+
+  + do not declare gets
+
+  + declare at_quick_exit and quick_exit also for ISO C11
+
+  + aligned_alloc.  NB: The code is deliberately allows the size parameter
+    to not be a multiple of the alignment.  This is a moronic requirement
+    in the standard but it is only a requirement on the caller, not the
+    implementation.
 
 
 Version 2.12.2

--- a/assert/assert.h
+++ b/assert/assert.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 1991,1992,1994-2001,2003,2004,2007,2011
+/* Copyright (C) 1991,1992,1994-2001,2003,2004,2007,2011,2012
    Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
@@ -115,7 +115,7 @@ __END_DECLS
 #endif /* NDEBUG.  */
 
 
-#ifdef __USE_ISOC11
+#if defined __USE_ISOC11 && !defined __cplusplus
 /* Static assertion.  Requires support in the compiler.  */
 # undef static_assert
 # define static_assert _Static_assert

--- a/assert/assert.h
+++ b/assert/assert.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 1991,1992,1994-2001,2003,2004,2007
+/* Copyright (C) 1991,1992,1994-2001,2003,2004,2007,2011
    Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
@@ -113,3 +113,10 @@ __END_DECLS
 # endif
 
 #endif /* NDEBUG.  */
+
+
+#ifdef __USE_ISOC11
+/* Static assertion.  Requires support in the compiler.  */
+# undef static_assert
+# define static_assert _Static_assert
+#endif

--- a/include/features.h
+++ b/include/features.h
@@ -98,6 +98,7 @@
 #undef	__USE_ISOC11
 #undef	__USE_ISOC99
 #undef	__USE_ISOC95
+#undef	__USE_ISOCXX11
 #undef	__USE_POSIX
 #undef	__USE_POSIX2
 #undef	__USE_POSIX199309
@@ -202,6 +203,15 @@
 #if (defined _ISOC99_SOURCE || defined _ISOC11_SOURCE \
      || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 199409L))
 # define __USE_ISOC95	1
+#endif
+
+/* This is to enable compatibility for ISO C++11.
+
+   So far g++ does not provide a macro.  Check the temporary macro for
+   now, too.  */
+#if ((defined __cplusplus && __cplusplus >= 201103L)			      \
+     || defined __GXX_EXPERIMENTAL_CXX0X__)
+# define __USE_ISOCXX11	1
 #endif
 
 /* If none of the ANSI/POSIX macros are defined, use POSIX.1 and POSIX.2

--- a/include/features.h
+++ b/include/features.h
@@ -24,6 +24,7 @@
 
    __STRICT_ANSI__	ISO Standard C.
    _ISOC99_SOURCE	Extensions to ISO C89 from ISO C99.
+   _ISOC11_SOURCE	Extensions to ISO C99 from ISO C11.
    _POSIX_SOURCE	IEEE Std 1003.1.
    _POSIX_C_SOURCE	If ==1, like _POSIX_SOURCE; if >=2 add IEEE Std 1003.2;
 			if >=199309L, add IEEE Std 1003.1b-1993;
@@ -56,6 +57,7 @@
    These are defined by this file and are used by the
    header files to decide what to declare or define:
 
+   __USE_ISOC11		Define ISO C11 things.
    __USE_ISOC99		Define ISO C99 things.
    __USE_ISOC95		Define ISO C90 AMD1 (C95) things.
    __USE_POSIX		Define IEEE Std 1003.1 things.
@@ -93,6 +95,7 @@
 
 
 /* Undefine everything, so we get a clean slate.  */
+#undef	__USE_ISOC11
 #undef	__USE_ISOC99
 #undef	__USE_ISOC95
 #undef	__USE_POSIX
@@ -156,6 +159,8 @@
 # define _ISOC95_SOURCE	1
 # undef  _ISOC99_SOURCE
 # define _ISOC99_SOURCE	1
+# undef  _ISOC11_SOURCE
+# define _ISOC11_SOURCE	1
 # undef  _POSIX_SOURCE
 # define _POSIX_SOURCE	1
 # undef  _POSIX_C_SOURCE
@@ -183,17 +188,18 @@
 # define _SVID_SOURCE	1
 #endif
 
-/* This is to enable the ISO C99 extension.  Also recognize the old macro
-   which was used prior to the standard acceptance.  This macro will
-   eventually go away and the features enabled by default once the ISO C99
-   standard is widely adopted.  */
-#if (defined _ISOC99_SOURCE || defined _ISOC9X_SOURCE \
+/* This is to enable the ISO C11 extension.  */
+#if (defined _ISOC11_SOURCE \
+     || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 201112L))
+
+/* This is to enable the ISO C99 extension.  */
+#if (defined _ISOC99_SOURCE || defined _ISOC11_SOURCE \
      || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L))
 # define __USE_ISOC99	1
 #endif
 
 /* This is to enable the ISO C90 Amendment 1:1995 extension.  */
-#if (defined _ISOC99_SOURCE || defined _ISOC9X_SOURCE \
+#if (defined _ISOC99_SOURCE || defined _ISOC11_SOURCE \
      || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 199409L))
 # define __USE_ISOC95	1
 #endif

--- a/include/features.h
+++ b/include/features.h
@@ -192,6 +192,8 @@
 /* This is to enable the ISO C11 extension.  */
 #if (defined _ISOC11_SOURCE \
      || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 201112L))
+# define __USE_ISOC11	1
+#endif
 
 /* This is to enable the ISO C99 extension.  */
 #if (defined _ISOC99_SOURCE || defined _ISOC11_SOURCE \

--- a/libio/stdio.h
+++ b/libio/stdio.h
@@ -625,7 +625,7 @@ extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
      __wur;
 
 #if !defined __USE_ISOC11 \
-    || (defined __cplusplus && __cplusplus <= 201103L)
+    || (defined __cplusplus && __cplusplus <= 201103L && !defined __USE_GNU)
 /* Get a newline-terminated string from stdin, removing the newline.
    DO NOT USE THIS FUNCTION!!  There is no limit on how much it will read.
 

--- a/libio/stdio.h
+++ b/libio/stdio.h
@@ -624,12 +624,18 @@ __BEGIN_NAMESPACE_STD
 extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
      __wur;
 
+#ifndef __USE_ISOC11
 /* Get a newline-terminated string from stdin, removing the newline.
    DO NOT USE THIS FUNCTION!!  There is no limit on how much it will read.
+
+   The function has been officially removed in ISO C11.  This opportunity
+   is used to also remove it from the GNU feature list.  It is now only
+   available when explicitly using an old ISO C, Unix, or POSIX standard.
 
    This function is a possible cancellation point and therefore not
    marked with __THROW.  */
 extern char *gets (char *__s) __wur;
+#endif
 __END_NAMESPACE_STD
 
 #ifdef __USE_GNU

--- a/libio/stdio.h
+++ b/libio/stdio.h
@@ -1,5 +1,5 @@
 /* Define ISO C stdio on top of C++ iostreams.
-   Copyright (C) 1991, 1994-2008, 2009, 2010 Free Software Foundation, Inc.
+   Copyright (C) 1991, 1994-2011, 2012 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -624,13 +624,16 @@ __BEGIN_NAMESPACE_STD
 extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
      __wur;
 
-#ifndef __USE_ISOC11
+#if !defined __USE_ISOC11 \
+    || (defined __cplusplus && __cplusplus <= 201103L)
 /* Get a newline-terminated string from stdin, removing the newline.
    DO NOT USE THIS FUNCTION!!  There is no limit on how much it will read.
 
    The function has been officially removed in ISO C11.  This opportunity
    is used to also remove it from the GNU feature list.  It is now only
    available when explicitly using an old ISO C, Unix, or POSIX standard.
+   GCC defines _GNU_SOURCE when building C++ code and the function is still
+   in C++11, so it is also available for C++.
 
    This function is a possible cancellation point and therefore not
    marked with __THROW.  */

--- a/libio/stdio.h
+++ b/libio/stdio.h
@@ -625,7 +625,7 @@ extern char *fgets (char *__restrict __s, int __n, FILE *__restrict __stream)
      __wur;
 
 #if !defined __USE_ISOC11 \
-    || (defined __cplusplus && __cplusplus <= 201103L && !defined __USE_GNU)
+    || (defined __cplusplus && __cplusplus <= 201103L)
 /* Get a newline-terminated string from stdin, removing the newline.
    DO NOT USE THIS FUNCTION!!  There is no limit on how much it will read.
 

--- a/malloc/malloc.c
+++ b/malloc/malloc.c
@@ -3904,6 +3904,8 @@ public_mEMALIGn(size_t alignment, size_t bytes)
 	 ar_ptr == arena_for_chunk(mem2chunk(p)));
   return p;
 }
+/* For ISO C11.  */
+weak_alias (public_mEMALIGn, aligned_alloc)
 #ifdef libc_hidden_def
 libc_hidden_def (public_mEMALIGn)
 #endif

--- a/ports/ChangeLog.arm
+++ b/ports/ChangeLog.arm
@@ -1,3 +1,27 @@
+2011-12-20  Peter Green  <plugwash@p10link.net>
+
+	* sysdeps/unix/sysv/linux/arm/sys/ucontext.h: Don't include
+	<sys/procfs.h>.
+	(gregset_t): Define without using elf_gregset_t.
+	(R0): Rename to REG_R0.
+	(R1): Rename to REG_R1.
+	(R2): Rename to REG_R2.
+	(R3): Rename to REG_R3.
+	(R4): Rename to REG_R4.
+	(R5): Rename to REG_R5.
+	(R6): Rename to REG_R6.
+	(R7): Rename to REG_R7.
+	(R8): Rename to REG_R8.
+	(R9): Rename to REG_R9.
+	(R10): Rename to REG_R10.
+	(R11): Rename to REG_R11.
+	(R12): Rename to REG_R12.
+	(R13): Rename to REG_R13.
+	(R14): Rename to REG_R14.
+	(R15): Rename to REG_R15.
+	(struct _libc_fpstate): New.
+	(fpregset_t): Define using struct _libc_fpstate.
+
 2010-05-21  Joseph Myers  <joseph@codesourcery.com>
 
 	* sysdeps/unix/sysv/linux/arm/eabi/internal_recvmmsg.S: New.

--- a/ports/sysdeps/arm/sys/ucontext.h
+++ b/ports/sysdeps/arm/sys/ucontext.h
@@ -32,42 +32,44 @@ typedef int greg_t;
 /* Container for all general registers.  */
 typedef greg_t gregset_t[NGREG];
 
+#ifdef __USE_MISC
 /* Number of each register is the `gregset_t' array.  */
 enum
 {
   R0 = 0,
-#define R0	R0
+# define R0	R0
   R1 = 1,
-#define R1	R1
+# define R1	R1
   R2 = 2,
-#define R2	R2
+# define R2	R2
   R3 = 3,
-#define R3	R3
+# define R3	R3
   R4 = 4,
-#define R4	R4
+# define R4	R4
   R5 = 5,
-#define R5	R5
+# define R5	R5
   R6 = 6,
-#define R6	R6
+# define R6	R6
   R7 = 7,
-#define R7	R7
+# define R7	R7
   R8 = 8,
-#define R8	R8
+# define R8	R8
   R9 = 9,
-#define R9	R9
+# define R9	R9
   R10 = 10,
-#define R10	R10
+# define R10	R10
   R11 = 11,
-#define R11	R11
+# define R11	R11
   R12 = 12,
-#define R12	R12
+# define R12	R12
   R13 = 13,
-#define R13	R13
+# define R13	R13
   R14 = 14,
-#define R14	R14
+# define R14	R14
   R15 = 15,
-#define R15	R15
+# define R15	R15
 };
+#endif
 
 /* Structure to describe FPU registers.  */
 typedef struct fpregset

--- a/ports/sysdeps/m68k/sys/ucontext.h
+++ b/ports/sysdeps/m68k/sys/ucontext.h
@@ -33,47 +33,48 @@ typedef int greg_t;
 /* Container for all general registers.  */
 typedef greg_t gregset_t[NGREG];
 
+#ifdef __USE_MISC
 /* Number of each register is the `gregset_t' array.  */
 enum
 {
   R_D0 = 0,
-#define R_D0	R_D0
+# define R_D0	R_D0
   R_D1 = 1,
-#define R_D1	R_D1
+# define R_D1	R_D1
   R_D2 = 2,
-#define R_D2	R_D2
+# define R_D2	R_D2
   R_D3 = 3,
-#define R_D3	R_D3
+# define R_D3	R_D3
   R_D4 = 4,
-#define R_D4	R_D4
+# define R_D4	R_D4
   R_D5 = 5,
-#define R_D5	R_D5
+# define R_D5	R_D5
   R_D6 = 6,
-#define R_D6	R_D6
+# define R_D6	R_D6
   R_D7 = 7,
-#define R_D7	R_D7
+# define R_D7	R_D7
   R_A0 = 8,
-#define R_A0	R_A0
+# define R_A0	R_A0
   R_A1 = 9,
-#define R_A1	R_A1
+# define R_A1	R_A1
   R_A2 = 10,
-#define R_A2	R_A2
+# define R_A2	R_A2
   R_A3 = 11,
-#define R_A3	R_A3
+# define R_A3	R_A3
   R_A4 = 12,
-#define R_A4	R_A4
+# define R_A4	R_A4
   R_A5 = 13,
-#define R_A5	R_A5
+# define R_A5	R_A5
   R_A6 = 14,
-#define R_A6	R_A6
+# define R_A6	R_A6
   R_A7 = 15,
-#define R_A7	R_A7
+# define R_A7	R_A7
   R_SP = 15,
-#define R_SP	R_SP
+# define R_SP	R_SP
   R_PC = 16,
-#define R_PC	R_PC
+# define R_PC	R_PC
   R_PS = 17
-#define R_PS	R_PS
+# define R_PS	R_PS
 };
 
 /* Structure to describe FPU registers.  */
@@ -84,6 +85,7 @@ typedef struct fpregset
   int f_fpiaddr;
   int f_fpregs[8][3];
 } fpregset_t;
+#endif
 
 /* Context to describe whole processor state.  */
 typedef struct
@@ -92,7 +94,9 @@ typedef struct
   gregset_t gregs;
 } mcontext_t;
 
-#define MCONTEXT_VERSION 1
+#ifdef __USE_MISC
+# define MCONTEXT_VERSION 1
+#endif
 
 /* Userlevel context.  */
 typedef struct ucontext

--- a/ports/sysdeps/mips/sys/ucontext.h
+++ b/ports/sysdeps/mips/sys/ucontext.h
@@ -38,82 +38,84 @@ typedef __uint64_t greg_t;
 /* Container for all general registers.  */
 typedef greg_t gregset_t[NGREG];
 
+#ifdef __USE_MISC
 /* Number of each register is the `gregset_t' array.  */
 enum
 {
   CTX_R0 = 0,
-#define CTX_R0	CTX_R0
+# define CTX_R0	CTX_R0
   CTX_AT = 1,
-#define CTX_AT	CTX_AT
+# define CTX_AT	CTX_AT
   CTX_V0 = 2,
-#define CTX_V0	CTX_V0
+# define CTX_V0	CTX_V0
   CTX_V1 = 3,
-#define CTX_V1	CTX_V1
+# define CTX_V1	CTX_V1
   CTX_A0 = 4,
-#define CTX_A0	CTX_A0
+# define CTX_A0	CTX_A0
   CTX_A1 = 5,
-#define CTX_A1	CTX_A1
+# define CTX_A1	CTX_A1
   CTX_A2 = 6,
-#define CTX_A2	CTX_A2
+# define CTX_A2	CTX_A2
   CTX_A3 = 7,
-#define CTX_A3	CTX_A3
+# define CTX_A3	CTX_A3
   CTX_T0 = 8,
-#define CTX_T0	CTX_T0
+# define CTX_T0	CTX_T0
   CTX_T1 = 9,
-#define CTX_T1	CTX_T1
+# define CTX_T1	CTX_T1
   CTX_T2 = 10,
-#define CTX_T2	CTX_T2
+# define CTX_T2	CTX_T2
   CTX_T3 = 11,
-#define CTX_T3	CTX_T3
+# define CTX_T3	CTX_T3
   CTX_T4 = 12,
-#define CTX_T4	CTX_T4
+# define CTX_T4	CTX_T4
   CTX_T5 = 13,
-#define CTX_T5	CTX_T5
+# define CTX_T5	CTX_T5
   CTX_T6 = 14,
-#define CTX_T6	CTX_T6
+# define CTX_T6	CTX_T6
   CTX_T7 = 15,
-#define CTX_T7	CTX_T7
+# define CTX_T7	CTX_T7
   CTX_S0 = 16,
-#define CTX_S0	CTX_S0
+# define CTX_S0	CTX_S0
   CTX_S1 = 17,
-#define CTX_S1	CTX_S1
+# define CTX_S1	CTX_S1
   CTX_S2 = 18,
-#define CTX_S2	CTX_S2
+# define CTX_S2	CTX_S2
   CTX_S3 = 19,
-#define CTX_S3	CTX_S3
+# define CTX_S3	CTX_S3
   CTX_S4 = 20,
-#define CTX_S4	CTX_S4
+# define CTX_S4	CTX_S4
   CTX_S5 = 21,
-#define CTX_S5	CTX_S5
+# define CTX_S5	CTX_S5
   CTX_S6 = 22,
-#define CTX_S6	CTX_S6
+# define CTX_S6	CTX_S6
   CTX_S7 = 23,
-#define CTX_S7	CTX_S7
+# define CTX_S7	CTX_S7
   CTX_T8 = 24,
-#define CTX_T8	CTX_T8
+# define CTX_T8	CTX_T8
   CTX_T9 = 25,
-#define CTX_T9	CTX_T9
+# define CTX_T9	CTX_T9
   CTX_K0 = 26,
-#define CTX_K0	CTX_K0
+# define CTX_K0	CTX_K0
   CTX_K1 = 27,
-#define CTX_K1	CTX_K1
+# define CTX_K1	CTX_K1
   CTX_GP = 28,
-#define CTX_GP	CTX_GP
+# define CTX_GP	CTX_GP
   CTX_SP = 29,
-#define CTX_SP	CTX_SP
+# define CTX_SP	CTX_SP
   CTX_S8 = 30,
-#define CTX_S8	CTX_S8
+# define CTX_S8	CTX_S8
   CTX_RA = 31,
-#define CTX_RA	CTX_RA
+# define CTX_RA	CTX_RA
   CTX_MDLO = 32,
-#define CTX_MDLO	CTX_MDLO
+# define CTX_MDLO	CTX_MDLO
   CTX_MDHI = 33,
-#define CTX_MDHI	CTX_MDHI
+# define CTX_MDHI	CTX_MDHI
   CTX_CAUSE = 34,
-#define CTX_CAUSE	CTX_CAUSE
+# define CTX_CAUSE	CTX_CAUSE
   CTX_EPC = 35,
-#define CTX_EPC	CTX_EPC
+# define CTX_EPC	CTX_EPC
 };
+#endif
 
 /* Structure to describe FPU registers.  */
 typedef struct fpregset

--- a/ports/sysdeps/unix/sysv/linux/arm/sys/ucontext.h
+++ b/ports/sysdeps/unix/sysv/linux/arm/sys/ucontext.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 1998, 1999, 2001, 2006 Free Software Foundation, Inc.
+/* Copyright (C) 1998, 1999, 2001, 2006, 2011 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -23,7 +23,6 @@
 
 #include <features.h>
 #include <signal.h>
-#include <sys/procfs.h>
 
 /* We need the signal context definitions even if they are not used
    included in <signal.h>.  */
@@ -35,47 +34,64 @@ typedef int greg_t;
 #define NGREG	18
 
 /* Container for all general registers.  */
-typedef elf_gregset_t gregset_t;
+typedef greg_t gregset_t[NGREG];
 
 /* Number of each register is the `gregset_t' array.  */
 enum
 {
-  R0 = 0,
-#define R0	R0
-  R1 = 1,
-#define R1	R1
-  R2 = 2,
-#define R2	R2
-  R3 = 3,
-#define R3	R3
-  R4 = 4,
-#define R4	R4
-  R5 = 5,
-#define R5	R5
-  R6 = 6,
-#define R6	R6
-  R7 = 7,
-#define R7	R7
-  R8 = 8,
-#define R8	R8
-  R9 = 9,
-#define R9	R9
-  R10 = 10,
-#define R10	R10
-  R11 = 11,
-#define R11	R11
-  R12 = 12,
-#define R12	R12
-  R13 = 13,
-#define R13	R13
-  R14 = 14,
-#define R14	R14
-  R15 = 15
-#define R15	R15
+  REG_R0 = 0,
+#define REG_R0	REG_R0
+  REG_R1 = 1,
+#define REG_R1	REG_R1
+  REG_R2 = 2,
+#define REG_R2	REG_R2
+  REG_R3 = 3,
+#define REG_R3	REG_R3
+  REG_R4 = 4,
+#define REG_R4	REG_R4
+  REG_R5 = 5,
+#define REG_R5	REG_R5
+  REG_R6 = 6,
+#define REG_R6	REG_R6
+  REG_R7 = 7,
+#define REG_R7	REG_R7
+  REG_R8 = 8,
+#define REG_R8	REG_R8
+  REG_R9 = 9,
+#define REG_R9	REG_R9
+  REG_R10 = 10,
+#define REG_R10	REG_R10
+  REG_R11 = 11,
+#define REG_R11	REG_R11
+  REG_R12 = 12,
+#define REG_R12	REG_R12
+  REG_R13 = 13,
+#define REG_R13	REG_R13
+  REG_R14 = 14,
+#define REG_R14	REG_R14
+  REG_R15 = 15
+#define REG_R15	REG_R15
 };
 
+struct _libc_fpstate
+{
+  struct
+  {
+    unsigned int sign1:1;
+    unsigned int unused:15;
+    unsigned int sign2:1;
+    unsigned int exponent:14;
+    unsigned int j:1;
+    unsigned int mantissa1:31;
+    unsigned int mantissa0:32;
+  } fpregs[8];
+  unsigned int fpsr:32;
+  unsigned int fpcr:32;
+  unsigned char ftype[8];
+  unsigned int init_flag;
+};
 /* Structure to describe FPU registers.  */
-typedef elf_fpregset_t	fpregset_t;
+typedef struct _libc_fpstate fpregset_t;
 
 /* Context to describe whole processor state.  This only describes
    the core registers; coprocessor registers get saved elsewhere

--- a/ports/sysdeps/unix/sysv/linux/arm/sys/ucontext.h
+++ b/ports/sysdeps/unix/sysv/linux/arm/sys/ucontext.h
@@ -28,10 +28,11 @@
    included in <signal.h>.  */
 #include <bits/sigcontext.h>
 
+#ifdef __USE_MISC
 typedef int greg_t;
 
 /* Number of general registers.  */
-#define NGREG	18
+# define NGREG	18
 
 /* Container for all general registers.  */
 typedef greg_t gregset_t[NGREG];
@@ -40,37 +41,37 @@ typedef greg_t gregset_t[NGREG];
 enum
 {
   REG_R0 = 0,
-#define REG_R0	REG_R0
+# define REG_R0	REG_R0
   REG_R1 = 1,
-#define REG_R1	REG_R1
+# define REG_R1	REG_R1
   REG_R2 = 2,
-#define REG_R2	REG_R2
+# define REG_R2	REG_R2
   REG_R3 = 3,
-#define REG_R3	REG_R3
+# define REG_R3	REG_R3
   REG_R4 = 4,
-#define REG_R4	REG_R4
+# define REG_R4	REG_R4
   REG_R5 = 5,
-#define REG_R5	REG_R5
+# define REG_R5	REG_R5
   REG_R6 = 6,
-#define REG_R6	REG_R6
+# define REG_R6	REG_R6
   REG_R7 = 7,
-#define REG_R7	REG_R7
+# define REG_R7	REG_R7
   REG_R8 = 8,
-#define REG_R8	REG_R8
+# define REG_R8	REG_R8
   REG_R9 = 9,
-#define REG_R9	REG_R9
+# define REG_R9	REG_R9
   REG_R10 = 10,
-#define REG_R10	REG_R10
+# define REG_R10	REG_R10
   REG_R11 = 11,
-#define REG_R11	REG_R11
+# define REG_R11	REG_R11
   REG_R12 = 12,
-#define REG_R12	REG_R12
+# define REG_R12	REG_R12
   REG_R13 = 13,
-#define REG_R13	REG_R13
+# define REG_R13	REG_R13
   REG_R14 = 14,
-#define REG_R14	REG_R14
+# define REG_R14	REG_R14
   REG_R15 = 15
-#define REG_R15	REG_R15
+# define REG_R15	REG_R15
 };
 
 struct _libc_fpstate
@@ -92,6 +93,7 @@ struct _libc_fpstate
 };
 /* Structure to describe FPU registers.  */
 typedef struct _libc_fpstate fpregset_t;
+#endif
 
 /* Context to describe whole processor state.  This only describes
    the core registers; coprocessor registers get saved elsewhere

--- a/ports/sysdeps/unix/sysv/linux/hppa/sys/ucontext.h
+++ b/ports/sysdeps/unix/sysv/linux/hppa/sys/ucontext.h
@@ -29,12 +29,13 @@
 #include <bits/sigcontext.h>
 
 
+#ifdef __USE_MISC
 /* Type for general register.  */
 typedef unsigned long int greg_t;
 
 /* Number of general registers.  */
-#define NGREG	80
-#define NFPREG	32
+# define NGREG	80
+# define NFPREG	32
 
 /* Container for all general registers.  */
 typedef struct gregset
@@ -50,6 +51,7 @@ typedef struct fpregset
   {
     double fp_dregs[32];
   } fpregset_t;
+#endif
 
 /* Context to describe whole processor state.  */
 typedef struct sigcontext mcontext_t;

--- a/ports/sysdeps/unix/sysv/linux/m68k/sys/ucontext.h
+++ b/ports/sysdeps/unix/sysv/linux/m68k/sys/ucontext.h
@@ -33,48 +33,50 @@ typedef int greg_t;
 /* Container for all general registers.  */
 typedef greg_t gregset_t[NGREG];
 
+#ifdef __USE_MISC
 /* Number of each register is the `gregset_t' array.  */
 enum
 {
   R_D0 = 0,
-#define R_D0	R_D0
+# define R_D0	R_D0
   R_D1 = 1,
-#define R_D1	R_D1
+# define R_D1	R_D1
   R_D2 = 2,
-#define R_D2	R_D2
+# define R_D2	R_D2
   R_D3 = 3,
-#define R_D3	R_D3
+# define R_D3	R_D3
   R_D4 = 4,
-#define R_D4	R_D4
+# define R_D4	R_D4
   R_D5 = 5,
-#define R_D5	R_D5
+# define R_D5	R_D5
   R_D6 = 6,
-#define R_D6	R_D6
+# define R_D6	R_D6
   R_D7 = 7,
-#define R_D7	R_D7
+# define R_D7	R_D7
   R_A0 = 8,
-#define R_A0	R_A0
+# define R_A0	R_A0
   R_A1 = 9,
-#define R_A1	R_A1
+# define R_A1	R_A1
   R_A2 = 10,
-#define R_A2	R_A2
+# define R_A2	R_A2
   R_A3 = 11,
-#define R_A3	R_A3
+# define R_A3	R_A3
   R_A4 = 12,
-#define R_A4	R_A4
+# define R_A4	R_A4
   R_A5 = 13,
-#define R_A5	R_A5
+# define R_A5	R_A5
   R_A6 = 14,
-#define R_A6	R_A6
+# define R_A6	R_A6
   R_A7 = 15,
-#define R_A7	R_A7
+# define R_A7	R_A7
   R_SP = 15,
-#define R_SP	R_SP
+# define R_SP	R_SP
   R_PC = 16,
-#define R_PC	R_PC
+# define R_PC	R_PC
   R_PS = 17
-#define R_PS	R_PS
+# define R_PS	R_PS
 };
+#endif
 
 /* Structure to describe FPU registers.  */
 typedef struct fpregset
@@ -97,7 +99,9 @@ typedef struct
   fpregset_t fpregs;
 } mcontext_t;
 
-#define MCONTEXT_VERSION 2
+#ifdef __USE_MISC
+# define MCONTEXT_VERSION 2
+#endif
 
 /* Userlevel context.  */
 typedef struct ucontext

--- a/stdlib/stdlib.h
+++ b/stdlib/stdlib.h
@@ -511,7 +511,8 @@ extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
 
 #ifdef __USE_ISOC11
 /* ISO C variant of aligned allocation.  */
-extern int aligned_alloc (size_t __alignment, size_t __size) __THROW __wur;
+extern void *aligned_alloc (size_t __alignment, size_t __size)
+     __THROW __wur __attribute__ ((__malloc__, __alloc_size__ (2)));
 #endif
 
 __BEGIN_NAMESPACE_STD

--- a/stdlib/stdlib.h
+++ b/stdlib/stdlib.h
@@ -517,9 +517,7 @@ extern void abort (void) __THROW __attribute__ ((__noreturn__));
 /* Register a function to be called when `exit' is called.  */
 extern int atexit (void (*__func) (void)) __THROW __nonnull ((1));
 
-#ifdef __USE_GNU
-// XXX There should be a macro to signal with C++ revision is used.
-// XXX This function is in the C++1x revision.
+#if defined __USE_ISOC11 || defined __USE_ISOCXX11
 /* Register a function to be called when `quick_exit' is called.  */
 # ifdef __cplusplus
 extern "C++" int at_quick_exit (void (*__func) (void))
@@ -543,9 +541,7 @@ __BEGIN_NAMESPACE_STD
    perform stdio cleanup, and terminate program execution with STATUS.  */
 extern void exit (int __status) __THROW __attribute__ ((__noreturn__));
 
-#ifdef __USE_GNU
-// XXX There should be a macro to signal with C++ revision is used.
-// XXX This function is in the C++1x revision.
+#if defined __USE_ISOC11 || defined __USE_ISOCXX11
 /* Call all functions registered with `at_quick_exit' in the reverse
    of the order in which they were registered and terminate program
    execution with STATUS.  */

--- a/stdlib/stdlib.h
+++ b/stdlib/stdlib.h
@@ -509,6 +509,11 @@ extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
      __THROW __nonnull ((1)) __wur;
 #endif
 
+#ifdef __USE_ISOC11
+/* ISO C variant of aligned allocation.  */
+extern int aligned_alloc (size_t __alignment, size_t __size) __THROW __wur;
+#endif
+
 __BEGIN_NAMESPACE_STD
 /* Abort execution and generate a core-dump.  */
 extern void abort (void) __THROW __attribute__ ((__noreturn__));

--- a/sysdeps/i386/sys/ucontext.h
+++ b/sysdeps/i386/sys/ucontext.h
@@ -33,48 +33,50 @@ typedef int greg_t;
 /* Container for all general registers.  */
 typedef greg_t gregset_t[NGREG];
 
+#ifdef __USE_MISC
 /* Number of each register is the `gregset_t' array.  */
 enum
 {
   REG_GS = 0,
-#define REG_GS	REG_GS
+# define REG_GS	REG_GS
   REG_FS,
-#define REG_FS	REG_FS
+# define REG_FS	REG_FS
   REG_ES,
-#define REG_ES	REG_ES
+# define REG_ES	REG_ES
   REG_DS,
-#define REG_DS	REG_DS
+# define REG_DS	REG_DS
   REG_EDI,
-#define REG_EDI	REG_EDI
+# define REG_EDI	REG_EDI
   REG_ESI,
-#define REG_ESI	REG_ESI
+# define REG_ESI	REG_ESI
   REG_EBP,
-#define REG_EBP	REG_EBP
+# define REG_EBP	REG_EBP
   REG_ESP,
-#define REG_ESP	REG_ESP
+# define REG_ESP	REG_ESP
   REG_EBX,
-#define REG_EBX	REG_EBX
+# define REG_EBX	REG_EBX
   REG_EDX,
-#define REG_EDX	REG_EDX
+# define REG_EDX	REG_EDX
   REG_ECX,
-#define REG_ECX	REG_ECX
+# define REG_ECX	REG_ECX
   REG_EAX,
-#define REG_EAX	REG_EAX
+# define REG_EAX	REG_EAX
   REG_TRAPNO,
-#define REG_TRAPNO	REG_TRAPNO
+# define REG_TRAPNO	REG_TRAPNO
   REG_ERR,
-#define REG_ERR	REG_ERR
+# define REG_ERR	REG_ERR
   REG_EIP,
-#define REG_EIP	REG_EIP
+# define REG_EIP	REG_EIP
   REG_CS,
-#define REG_CS	REG_CS
+# define REG_CS	REG_CS
   REG_EFL,
-#define REG_EFL	REG_EFL
+# define REG_EFL	REG_EFL
   REG_UESP,
-#define REG_UESP	REG_UESP
+# define REG_UESP	REG_UESP
   REG_SS
-#define REG_SS	REG_SS
+# define REG_SS	REG_SS
 };
+#endif
 
 /* Structure to describe FPU registers.  */
 typedef struct fpregset

--- a/sysdeps/unix/sysv/linux/sh/sh4/sys/ucontext.h
+++ b/sysdeps/unix/sysv/linux/sh/sh4/sys/ucontext.h
@@ -37,42 +37,42 @@ typedef int greg_t;
 /* Container for all general registers.  */
 typedef greg_t gregset_t[NFPREG];
 
-#ifdef __USE_GNU
+#ifdef __USE_MISC
 /* Number of each register is the `gregset_t' array.  */
 enum
 {
-  R0 = 0,
-#define R0	R0
-  R1 = 1,
-#define R1	R1
-  R2 = 2,
-#define R2	R2
-  R3 = 3,
-#define R3	R3
-  R4 = 4,
-#define R4	R4
-  R5 = 5,
-#define R5	R5
-  R6 = 6,
-#define R6	R6
-  R7 = 7,
-#define R7	R7
-  R8 = 8,
-#define R8	R8
-  R9 = 9,
-#define R9	R9
-  R10 = 10,
-#define R10	R10
-  R11 = 11,
-#define R11	R11
-  R12 = 12,
-#define R12	R12
-  R13 = 13,
-#define R13	R13
-  R14 = 14,
-#define R14	R14
-  R15 = 15,
-#define R15	R15
+  REG_R0 = 0,
+# define REG_R0	REG_R0
+  REG_R1 = 1,
+# define REG_R1	REG_R1
+  REG_R2 = 2,
+# define REG_R2	REG_R2
+  REG_R3 = 3,
+# define REG_R3	REG_R3
+  REG_R4 = 4,
+# define REG_R4	REG_R4
+  REG_R5 = 5,
+# define REG_R5	REG_R5
+  REG_R6 = 6,
+# define REG_R6	REG_R6
+  REG_R7 = 7,
+# define REG_R7	REG_R7
+  REG_R8 = 8,
+# define REG_R8	REG_R8
+  REG_R9 = 9,
+# define REG_R9	REG_R9
+  REG_R10 = 10,
+# define REG_R10	REG_R10
+  REG_R11 = 11,
+# define REG_R11	REG_R11
+  REG_R12 = 12,
+# define REG_R12	REG_R12
+  REG_R13 = 13,
+# define REG_R13	REG_R13
+  REG_R14 = 14,
+# define REG_R14	REG_R14
+  REG_R15 = 15,
+# define REG_R15	REG_R15
 };
 #endif
 

--- a/wcsmbs/Makefile
+++ b/wcsmbs/Makefile
@@ -22,7 +22,7 @@
 #
 subdir	:= wcsmbs
 
-headers	:= wchar.h bits/wchar.h bits/wchar2.h bits/wchar-ldbl.h
+headers	:= wchar.h bits/wchar.h bits/wchar2.h bits/wchar-ldbl.h uchar.h
 distribute := wcwidth.h wcsmbsload.h
 
 routines := wcscat wcschr wcscmp wcscpy wcscspn wcsdup wcslen wcsncat \

--- a/wcsmbs/uchar.h
+++ b/wcsmbs/uchar.h
@@ -1,0 +1,76 @@
+/* Copyright (C) 2011 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, write to the Free
+   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+   02111-1307 USA.  */
+
+/*
+ *      ISO C11 Standard: 7.28
+ *	Unicode utilities	<uchar.h>
+ */
+
+#ifndef _UCHAR_H
+#define _UCHAR_H	1
+
+#include <features.h>
+
+#define __need_size_t
+#include <stddef.h>
+#define __need_mbstate_t
+#include <wchar.h>
+
+
+#ifdef __GNUC__
+/* Define the 16-bit and 32-bit character types.  Use the information
+   provided by the compiler.  */
+# if !defined __CHAR16_TYPE__ || !defined __CHAR32_TYPE__
+#  if defined __STDC__ && __STDC__ < 201000L
+#   error "<uchar.h> requires ISO C11 mode"
+#  else
+#   error "definitions of __CHAR16_TYPE__ and/or __CHAR32_TYPE__ missing"
+#  endif
+# endif
+typedef __CHAR16_TYPE__ char16_t;
+typedef __CHAR32_TYPE__ char32_t;
+#endif
+
+
+__BEGIN_DECLS
+
+/* Write char16_t representation of multibyte character pointed
+   to by S to PC16.  */
+extern size_t mbrtoc16 (char16_t *__restrict __pc16,
+			__const char *__restrict __s, size_t __n,
+			mbstate_t *__restrict __p) __THROW;
+
+/* Write multibyte representation of char16_t C16 to S.  */
+extern size_t c16rtomb (char *__restrict __s, char16_t __c16,
+			mbstate_t *__restrict __ps) __THROW;
+
+
+
+/* Write char32_t representation of multibyte character pointed
+   to by S to PC32.  */
+extern size_t mbrtoc32 (char32_t *__restrict __pc32,
+			__const char *__restrict __s, size_t __n,
+			mbstate_t *__restrict __p) __THROW;
+
+/* Write multibyte representation of char32_t C32 to S.  */
+extern size_t c32rtomb (char *__restrict __s, char32_t __c32,
+			mbstate_t *__restrict __ps) __THROW;
+
+__END_DECLS
+
+#endif	/* uchar.h */

--- a/wcsmbs/uchar.h
+++ b/wcsmbs/uchar.h
@@ -49,6 +49,9 @@ typedef __CHAR32_TYPE__ char32_t;
 
 __BEGIN_DECLS
 
+/* Available starting from glibc 2.16. If we're going to declare them,
+   we should provide a polyfill.  */
+#if 0
 /* Write char16_t representation of multibyte character pointed
    to by S to PC16.  */
 extern size_t mbrtoc16 (char16_t *__restrict __pc16,
@@ -70,6 +73,7 @@ extern size_t mbrtoc32 (char32_t *__restrict __pc32,
 /* Write multibyte representation of char32_t C32 to S.  */
 extern size_t c32rtomb (char *__restrict __s, char32_t __c32,
 			mbstate_t *__restrict __ps) __THROW;
+#endif
 
 __END_DECLS
 

--- a/wcsmbs/uchar.h
+++ b/wcsmbs/uchar.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2011 Free Software Foundation, Inc.
+/* Copyright (C) 2011, 2012 Free Software Foundation, Inc.
    This file is part of the GNU C Library.
 
    The GNU C Library is free software; you can redistribute it and/or
@@ -32,7 +32,7 @@
 #include <wchar.h>
 
 
-#ifdef __GNUC__
+#if defined __GNUC__ && !defined __USE_ISOCXX11
 /* Define the 16-bit and 32-bit character types.  Use the information
    provided by the compiler.  */
 # if !defined __CHAR16_TYPE__ || !defined __CHAR32_TYPE__


### PR DESCRIPTION
This PR adds some basic C11 support to glibc headers, mostly in order to get `aligned_alloc` working. This hasn't really been tested though.

It also cleans up some of the namespace pollution coming from `sys/ucontext.h` (e.g., `R0`, `R1`, etc.). This fixes an issue building [Citra](/citra-emu/citra). The changes for platforms other than 32-bit ARM may be broken. (I don't think this glibc even supports aarch64.) MIPS and x86 should be fine though.